### PR TITLE
Fix missing parameter when calling OtherLinuxSetup func

### DIFF
--- a/Setup/Setup_lib.py
+++ b/Setup/Setup_lib.py
@@ -60,7 +60,7 @@ def AutoSetup():
 
         else:
 
-            OtherLinuxSetup()
+            OtherLinuxSetup(rel)
 
     elif pl == "darwin":
 


### PR DESCRIPTION
Fix #70 