### PR TITLE
Fixed OtherLinuxSetup function call

### DIFF
--- a/Setup/Setup_lib.py
+++ b/Setup/Setup_lib.py
@@ -60,7 +60,7 @@ def AutoSetup():
 
         else:
 
-            OtherLinuxSetup()
+            OtherLinuxSetup(rel)
 
     elif pl == "darwin":
 


### PR DESCRIPTION
Fixed OtherLinuxSetup function call

Added the missing `rel` argument in the call of the OtherLinuxSetup function