### PR TITLE
Fixed OpenSSL.crypto has no attribute PKCS12Type problem

### DIFF
--- a/Setup/Phantom_lib.py
+++ b/Setup/Phantom_lib.py
@@ -436,7 +436,7 @@ def ExeSigner(Filename,Spoofcert,descr="Notepad Benchmark Util"):
         cert.set_notAfter(x509.get_notAfter())
         cert.set_pubkey(keygen)
         cert.sign(keygen, 'sha256')
-        pfx = crypto.PKCS12Type()
+        pfx = crypto.PKCS12()
         pfx.set_privatekey(keygen)
         pfx.set_certificate(cert)
         pfxdata = pfx.export()


### PR DESCRIPTION
I changed changed PKCS12Type to PKCS12  cuz i had  "OpenSSL.crypto has no attribute PKCS12Type problem" with python3 in kali 2020.4